### PR TITLE
Add Custom Range Search and Reuse Intermediate Results Range Search Strategies

### DIFF
--- a/.github/workflows/page_search.yml
+++ b/.github/workflows/page_search.yml
@@ -1,5 +1,5 @@
 name: DiskANN and Page Search Functionality Tests
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   build-and-run:
     name: Run on ${{ matrix.os }} and ${{ matrix.data_type }} dataset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,8 @@ else()
 endif()
 
 add_subdirectory(src)
-add_subdirectory(tests)
 add_subdirectory(tests/utils)
+add_subdirectory(tests)
 
 if (MSVC)
     message(STATUS "The ${PROJECT_NAME}.sln has been created, opened it from VisualStudio to build Release or Debug configurations.\n"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For building, modify `MEM_R`, `MEM_BUILD_L`, `MEM_ALPHA`, `MEM_RAND_SAMPLING_RAT
 ./run_benchmark.sh [debug/release] build_mem
 ```
 
-For searching, modify `mem_L` and `mem_topk` to enable
+For searching, modify `mem_L` to enable
 ```bash
 ./run_benchmark.sh [debug/release] search [knn/range]
 ```

--- a/include/aux_utils.h
+++ b/include/aux_utils.h
@@ -68,7 +68,7 @@ namespace diskann {
 
   DISKANN_DLLEXPORT double calculate_range_search_recall(
       unsigned num_queries, std::vector<std::vector<_u32>> &groundtruth,
-      std::vector<std::vector<_u32>> &our_results);
+      std::vector<std::vector<_u64>> &our_results);
 
   DISKANN_DLLEXPORT void read_idmap(const std::string &    fname,
                                     std::vector<unsigned> &ivecs);

--- a/include/index.h
+++ b/include/index.h
@@ -184,7 +184,14 @@ namespace diskann {
     DISKANN_DLLEXPORT size_t search_with_tags(const T *query, const uint64_t K,
                                               const unsigned L, TagT *tags,
                                               float *           distances,
+                                              _u32 *            return_indices,
                                               std::vector<T *> &res_vectors);
+
+    // The function will modify nbrs to contain all the nodes it can reach
+    // after BFS
+    DISKANN_DLLEXPORT void bfs_with_tags(const T* query,
+                                    const double range,
+                                    std::vector<MemNavNeighbor> &nbrs);
 
     // Will fail if tag already in the index
     DISKANN_DLLEXPORT int insert_point(const T *point, const TagT tag);

--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -33,6 +33,17 @@ namespace diskann {
     }
   };
 
+  struct MemNavNeighbor {
+    unsigned id;
+    float distance;
+    unsigned tag;
+
+    MemNavNeighbor(unsigned i, float d, unsigned t)
+        : id{i}, distance{d}, tag{t} {
+    }
+  };
+
+
   struct SimpleNeighbor {
     unsigned id;
     float    distance;
@@ -86,6 +97,88 @@ namespace diskann {
       return K + 1;
     memmove((char *) &addr[right + 1], &addr[right],
             (K - right) * sizeof(Neighbor));
+    addr[right] = nn;
+    return right;
+  }
+
+  // This class maintains a fixed-size sorted vector which supports
+  //    1. if the vector is full and the distance of the inserting element is
+  //       larger than the last element, early return. Otherwise, O(logN) insert
+  //    2. move the first `num` elements to another vector
+  class NeighborVec {
+  public:
+    void set_cap(size_t cap) {
+      v.resize(cap+1);
+      cap_ = cap;
+      size_ = std::min(size_, cap_);
+    }
+
+    void insert(const Neighbor &nn) {
+      if (size_ == 0 && cap_) {
+        v[size_] = nn;
+      } else {
+        if (size_ == cap_ && nn.distance >= v[size_-1].distance) return;
+        InsertIntoPool(v.data(), size_, nn);
+      }
+
+      if (size_ < cap_) ++size_;
+    }
+
+    size_t move_to(std::vector<Neighbor>& des, size_t des_idx, size_t num) {
+      if (num > size_) {
+        std::cout << "warning: require more neighbors than having. num: " << num << " size_: " << size_ << std::endl;
+      }
+      num = std::min(num, size_);
+      if (des_idx + num >= des.size()) {
+        std::cerr << "des size error" << std::endl;
+        exit(1);
+      }
+      memmove(&(des.data()[des_idx]), v.data(), num * sizeof(Neighbor));
+      if (size_ - num) {
+        memmove(v.data(), &(v.data()[num]), (size_ - num)*sizeof(Neighbor));
+      }
+      size_ -= num;
+      return num;
+    }
+  private:
+    std::vector<Neighbor> v;
+    size_t cap_ = 0, size_ = 0;
+  };
+
+  static inline unsigned InsertIntoPool(Neighbor *addr, unsigned K,
+                                        Neighbor nn, NeighborVec& kicked, unsigned L) {
+    // find the location to insert
+    unsigned left = 0, right = K - 1;
+    if (addr[left].distance > nn.distance) {
+      memmove((char *) &addr[left + 1], &addr[left], K * sizeof(Neighbor));
+      if (K == L) kicked.insert(addr[K]);
+      addr[left] = nn;
+      return left;
+    }
+    if (addr[right].distance < nn.distance) {
+      addr[K] = nn;
+      return K;
+    }
+    while (right > 1 && left < right - 1) {
+      unsigned mid = (left + right) / 2;
+      if (addr[mid].distance > nn.distance)
+        right = mid;
+      else
+        left = mid;
+    }
+
+    while (left > 0) {
+      if (addr[left].distance < nn.distance)
+        break;
+      if (addr[left].id == nn.id)
+        return K + 1;
+      left--;
+    }
+    if (addr[left].id == nn.id || addr[right].id == nn.id)
+      return K + 1;
+    memmove((char *) &addr[right + 1], &addr[right],
+            (K - right) * sizeof(Neighbor));
+    if (K == L) kicked.insert(addr[K]);
     addr[right] = nn;
     return right;
   }

--- a/include/percentile_stats.h
+++ b/include/percentile_stats.h
@@ -61,4 +61,38 @@ namespace diskann {
     }
     return avg / len;
   }
+
+  // The following two functions are used when getting statistics while range searching on only queries with
+  // non-zero gt lengths
+  template<typename T>
+  inline T get_percentile_stats_gt(
+      QueryStats *stats, uint64_t len, float percentile,
+      const std::function<T(const QueryStats &)> &member_fn, std::vector<std::vector<uint32_t>> &gt) {
+    std::vector<T> vals;
+    for (uint64_t i = 0; i < len; i++) {
+      if (gt[i].size()) vals.push_back(member_fn(stats[i]));
+    }
+
+    std::sort(vals.begin(), vals.end(),
+              [](const T &left, const T &right) { return left < right; });
+
+    auto retval = vals[(uint64_t)(percentile * vals.size())];
+    vals.clear();
+    return retval;
+  }
+
+  template<typename T>
+  inline double get_mean_stats_gt(
+      QueryStats *stats, uint64_t len,
+      const std::function<T(const QueryStats &)> &member_fn, std::vector<std::vector<uint32_t>> &gt) {
+    uint32_t cnt = 0;
+    double avg = 0;
+    for (uint64_t i = 0; i < len; i++) {
+      if (gt[i].size()) {
+        ++cnt;
+        avg += (double) member_fn(stats[i]);
+      }
+    }
+    return avg / cnt;
+  }
 }  // namespace diskann

--- a/include/utils.h
+++ b/include/utils.h
@@ -931,14 +931,6 @@ inline bool validate_index_file_size(std::ifstream& in) {
   return true;
 }
 
-inline bool validate_mem_index_params(const _u32 mem_topk, const _u32 mem_L) {
-  if (mem_L && (mem_L < mem_topk)) {
-    diskann::cerr << "mem_L should be equal or larger than mem_topk" << std::endl;
-    return false;
-  }
-  return true;
-}
-
 // This function is valid only for float data type.
 template<typename T>
 inline void normalize(T* arr, size_t dim) {

--- a/scripts/config_sample.sh
+++ b/scripts/config_sample.sh
@@ -13,7 +13,7 @@ dataset_sift10M
 R=48
 BUILD_L=128
 M=32
-BUILD_T=64
+BUILD_T=8
 
 ##################################
 #   In-Memory Navigation Graph   #
@@ -22,7 +22,7 @@ MEM_R=48
 MEM_BUILD_L=128
 MEM_ALPHA=1.2
 MEM_RAND_SAMPLING_RATE=0.01
-MEM_USE_FREQ=1
+MEM_USE_FREQ=0
 MEM_FREQ_USE_RATE=0.01
 
 ##########################
@@ -51,10 +51,9 @@ GP_CUT=4096 # the graph's degree will been limited at 4096
 #   Search   #
 ##############
 BM_LIST=(4)
-T_LIST=(16)
+T_LIST=(8)
 CACHE=0
 MEM_L=0 # non-zero to enable
-MEM_TOPK=10
 
 # Page Search
 USE_PAGE_SEARCH=1 # Set 0 for beam search, 1 for page search (default)
@@ -64,4 +63,7 @@ PS_USE_RATIO=1.0
 LS="100 120"
 
 # Range search
-RS_LS="80 100"
+RS_LS="80"
+RS_ITER_KNN_TO_RANGE_SEARCH=1 # 0 for custom search, 1 for iterating via KNN, combine with USE_PAGE_SEARCH
+KICKED_SIZE=300 # non-zero to reuse intermediate states during page search
+RS_CUSTOM_ROUND=0 # set when use custom search, 0 for all pages within radius

--- a/scripts/multiple_runs.sh
+++ b/scripts/multiple_runs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+SUMMARY_PATH=../indices/summary.log
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+rm $SUMMARY_PATH
+
+for l in 5 25 50 ; do
+  echo "RS_LS=\"${l}\"" >> config_local.sh
+
+for bm in 4 8 16; do
+  echo "BM_LIST=(${bm})" >> config_local.sh
+# for ml in 50 100 200; do
+# for ml in 50 200; do
+#   echo "MEM_L=${ml}" >> config_local.sh
+
+# for knn_ml in 20 40 80; do
+#   echo "RS_KNN_MEM_L=${ml}" >> config_local.sh
+
+# for ks in 500; do
+  echo "KICKED_SIZE=${ks}" >> config_local.sh
+  for i in $(seq 1 $1); do
+    printf "${GREEN}Run $i ${NC}\n"
+    ./run_benchmark.sh release search range
+  done
+done
+done
+# done
+# done
+
+printf "${GREEN}Summary${NC}\n"
+cat $SUMMARY_PATH | grep -E "([0-9]+(\.[0-9]+\s+)){5,}"

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -7,7 +7,7 @@ source config_local.sh
 
 INDEX_PREFIX_PATH="${PREFIX}_M${M}_R${R}_L${BUILD_L}_B${B}/"
 MEM_SAMPLE_PATH="${INDEX_PREFIX_PATH}SAMPLE_RATE_${MEM_RAND_SAMPLING_RATE}/"
-MEM_INDEX_PATH="${INDEX_PREFIX_PATH}MEM_R_${MEM_R}_L_${MEM_BUILD_L}_ALPHA_${MEM_ALPHA}_MEM_USE_FREQ${MEM_USE_FREQ}/"
+MEM_INDEX_PATH="${INDEX_PREFIX_PATH}MEM_R_${MEM_R}_L_${MEM_BUILD_L}_ALPHA_${MEM_ALPHA}_MEM_USE_FREQ${MEM_USE_FREQ}_RANDOM_RATE${MEM_RAND_SAMPLING_RATE}_FREQ_RATE${MEM_FREQ_USE_RATE}/"
 GP_PATH="${INDEX_PREFIX_PATH}GP_TIMES_${GP_TIMES}_LOCK_${GP_LOCK_NUMS}_GP_USE_FREQ${GP_USE_FREQ}_CUT${GP_CUT}/"
 FREQ_PATH="${INDEX_PREFIX_PATH}FREQ/NQ_${FREQ_QUERY_CNT}_BM_${FREQ_BM}_L_${FREQ_L}_T_${FREQ_T}/"
 
@@ -114,7 +114,6 @@ case $2 in
               -L $FREQ_L \
               -W $FREQ_BM \
               --mem_L ${FREQ_MEM_L} \
-              --mem_topk ${FREQ_MEM_TOPK} \
               --use_page_search 0 \
               --disk_file_path ${DISK_FILE_PATH} > ${FREQ_LOG}
   ;;
@@ -190,7 +189,6 @@ case $2 in
               -L ${LS} \
               -W $BW \
               --mem_L ${MEM_L} \
-              --mem_topk ${MEM_TOPK} \
               --mem_index_path ${MEM_INDEX_PATH}_index \
               --use_page_search ${USE_PAGE_SEARCH} \
               --use_ratio ${PS_USE_RATIO} \
@@ -200,16 +198,11 @@ case $2 in
         done
       ;;
       range)
-        # TODO: Range search needs to be modified
-        echo "Support only KNN for now"
-        exit 0
-
-        log_arr=()
         for BW in ${BM_LIST[@]}
         do
           for T in ${T_LIST[@]}
           do
-            SEARCH_LOG=${INDEX_PREFIX_PATH}search/search_RADIUS${RADIUS}_CACHE${CACHE}_BW${BW}_T${T}_MEML${MEM_L}_MEMK${MEM_TOPK}.log
+            SEARCH_LOG=${INDEX_PREFIX_PATH}search/search_RADIUS${RADIUS}_CACHE${CACHE}_BW${BW}_T${T}_PS${USE_PAGE_SEARCH}_PS_RATIO${PS_USE_RATIO}_ITER_KNN${RS_ITER_KNN_TO_RANGE_SEARCH}_MEM_L${MEM_L}.log
             echo "Searching... log file: ${SEARCH_LOG}"
             sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; ${EXE_PATH}/tests/range_search_disk_index \
               --data_type $DATA_TYPE \
@@ -222,9 +215,14 @@ case $2 in
               --gt_file $GT_FILE \
               --range_threshold $RADIUS \
               -L $RS_LS \
-              --mem_L ${MEM_L} \
-              --mem_topk ${MEM_TOPK} \
+              --disk_file_path ${DISK_FILE_PATH} \
+              --use_page_search ${USE_PAGE_SEARCH} \
+              --iter_knn_to_range_search ${RS_ITER_KNN_TO_RANGE_SEARCH} \
+              --use_ratio ${PS_USE_RATIO} \
               --mem_index_path ${MEM_INDEX_PATH}_index \
+              --mem_L ${MEM_L} \
+              --custom_round_num ${RS_CUSTOM_ROUND} \
+              --kicked_size ${KICKED_SIZE} \
               > ${SEARCH_LOG}
             log_arr+=( ${SEARCH_LOG} )
           done

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,8 @@ else()
     set(CPP_SOURCES ann_exception.cpp aux_utils.cpp distance.cpp index.cpp
         linux_aligned_file_reader.cpp math_utils.cpp natural_number_map.cpp
         natural_number_set.cpp memory_mapper.cpp partition_and_pq.cpp
-        pq_flash_index.cpp logger.cpp utils.cpp page_search.cpp visit_freq.cpp)
+        pq_flash_index.cpp logger.cpp utils.cpp page_search.cpp visit_freq.cpp
+        range_search.cpp)
     add_library(${PROJECT_NAME} ${CPP_SOURCES})
     add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})
 endif()

--- a/src/aux_utils.cpp
+++ b/src/aux_utils.cpp
@@ -261,9 +261,9 @@ namespace diskann {
 
   double calculate_range_search_recall(
       unsigned num_queries, std::vector<std::vector<_u32>> &groundtruth,
-      std::vector<std::vector<_u32>> &our_results) {
+      std::vector<std::vector<_u64>> &our_results) {
     double             total_recall = 0;
-    std::set<unsigned> gt, res;
+    std::set<_u64> gt, res;
 
     for (size_t i = 0; i < num_queries; i++) {
       gt.clear();

--- a/src/page_search.cpp
+++ b/src/page_search.cpp
@@ -36,9 +36,9 @@ namespace diskann {
 
   template<typename T>
   void PQFlashIndex<T>::page_search(
-      const T *query1, const _u64 k_search, const _u64 l_search, _u64 *indices,
+      const T *query1, const _u64 k_search, const _u32 mem_L, const _u64 l_search, _u64 *indices,
       float *distances, const _u64 beam_width, const _u32 io_limit,
-      const bool use_reorder_data, float use_ratio, QueryStats *stats) {
+      const bool use_reorder_data, const float use_ratio, QueryStats *stats) {
     ThreadData<T> data = this->thread_data.pop();
     while (data.scratch.sector_scratch == nullptr) {
       this->thread_data.wait_for_push_notify();
@@ -176,11 +176,12 @@ namespace diskann {
       }
     };
 
-    if (mem_L_) {
-      std::vector<unsigned> mem_tags(mem_topk_);
+    if (mem_L) {
+      std::vector<unsigned> mem_tags(mem_L);
+      std::vector<float> mem_dists(mem_L);
       std::vector<T*> res = std::vector<T*>();
-      mem_index_->search_with_tags(query, mem_topk_, mem_L_, mem_tags.data(), nullptr, res);
-      compute_and_add_to_retset(mem_tags.data(), std::min((unsigned)mem_topk_,(unsigned)l_search));
+      mem_index_->search_with_tags(query, mem_L, mem_L, mem_tags.data(), mem_dists.data(), nullptr, res);
+      compute_and_add_to_retset(mem_tags.data(), std::min((unsigned)mem_L,(unsigned)l_search));
     } else {
       compute_and_add_to_retset(&best_medoid, 1);
     }
@@ -383,6 +384,287 @@ namespace diskann {
     if (stats != nullptr) {
       stats->total_us = (double) query_timer.elapsed();
     }
+  }
+
+  template<typename T>
+  void PQFlashIndex<T>::page_search_interim(
+      const T *query1, const _u64 k_search, const _u32 mem_L, const _u64 l_search, _u64 *indices,
+      float *distances, const _u64 beam_width, const _u32 io_limit,
+      const bool use_reorder_data, const float use_ratio, QueryStats *stats, PageSearchPersistData<T>* persist_data) {
+
+    if (persist_data == nullptr) {
+      std::cerr << "this function needs persistent data" << std::endl;
+      exit(1);
+    }
+
+    std::vector<Neighbor>& retset = persist_data->ret_set;
+    NeighborVec& kicked = persist_data->kicked;
+    std::vector<Neighbor>& full_retset= persist_data->full_ret_set;
+    ThreadData<T>& data = persist_data->thread_data;
+    unsigned cur_list_size = persist_data->cur_list_size;
+    auto query_scratch = &(data.scratch);
+    float *pq_dists = query_scratch->aligned_pqtable_dist_scratch;
+    T *data_buf = query_scratch->coord_scratch;
+    _mm_prefetch((char *) data_buf, _MM_HINT_T1);
+    const T *query = data.scratch.aligned_query_T;
+    const float *query_float = data.scratch.aligned_query_float;
+    IOContext &ctx = data.ctx;
+
+    char *sector_scratch = query_scratch->sector_scratch;
+    _u64 &sector_scratch_idx = query_scratch->sector_idx;
+    float *dist_scratch = query_scratch->aligned_dist_scratch;
+    _u8 *  pq_coord_scratch = query_scratch->aligned_pq_coord_scratch;
+    tsl::robin_set<_u64> &visited = *(query_scratch->visited);
+    tsl::robin_set<unsigned> &page_visited = *(query_scratch->page_visited);
+
+    if (beam_width > MAX_N_SECTOR_READS)
+      throw ANNException("Beamwidth can not be higher than MAX_N_SECTOR_READS",
+                         -1, __FUNCSIG__, __FILE__, __LINE__);
+
+    // lambda to batch compute query<-> node distances in PQ space
+    auto compute_pq_dists = [this, pq_coord_scratch, pq_dists](const unsigned *ids,
+                                                            const _u64 n_ids,
+                                                            float *dists_out) {
+      pq_flash_index_utils::aggregate_coords(ids, n_ids, this->data, this->n_chunks,
+                         pq_coord_scratch);
+      pq_flash_index_utils::pq_dist_lookup(pq_coord_scratch, n_ids, this->n_chunks, pq_dists,
+                       dists_out);
+    };
+
+    auto compute_extact_dists_and_push = [&](const char* node_buf, const unsigned id) -> float {
+      T *node_fp_coords_copy = data_buf;
+      memcpy(node_fp_coords_copy, node_buf, disk_bytes_per_point);
+      float cur_expanded_dist = dist_cmp->compare(query, node_fp_coords_copy,
+                                            (unsigned) aligned_dim);
+      full_retset.push_back(Neighbor(id, cur_expanded_dist, true));
+      return cur_expanded_dist;
+    };
+
+    auto compute_and_push_nbrs = [&](const char *node_buf, unsigned& nk) {
+      unsigned *node_nbrs = OFFSET_TO_NODE_NHOOD(node_buf);
+      unsigned nnbrs = *(node_nbrs++);
+      unsigned nbors_cand_size = 0;
+      for (unsigned m = 0; m < nnbrs; ++m) {
+        if (visited.find(node_nbrs[m]) == visited.end()) {
+          node_nbrs[nbors_cand_size++] = node_nbrs[m];
+          visited.insert(node_nbrs[m]);
+        }
+      }
+      if (nbors_cand_size) {
+        compute_pq_dists(node_nbrs, nbors_cand_size, dist_scratch);
+        for (unsigned m = 0; m < nbors_cand_size; ++m) {
+          const int nbor_id = node_nbrs[m];
+          const float nbor_dist = dist_scratch[m];
+          if (stats != nullptr) {
+            stats->n_cmps++;
+          }
+          if (nbor_dist >= retset[cur_list_size - 1].distance &&
+              (cur_list_size == l_search)) {
+            kicked.insert(Neighbor(nbor_id, nbor_dist, true));
+            continue;
+          }
+          Neighbor nn(nbor_id, nbor_dist, true);
+          // Return position in sorted list where nn inserted
+          auto     r = InsertIntoPool(retset.data(), cur_list_size, nn, kicked, l_search);
+          if (cur_list_size < l_search) ++cur_list_size;
+          // nk logs the best position in the retset that was updated due to neighbors of n.
+          if (r < nk) nk = r;
+        }
+      }
+    };
+
+    unsigned num_ios = 0;
+    unsigned k = 0;
+
+    // cleared every iteration
+    std::vector<unsigned> frontier;
+    frontier.reserve(2 * beam_width);
+    std::vector<std::pair<unsigned, char *>> frontier_nhoods;
+    frontier_nhoods.reserve(2 * beam_width);
+    std::vector<AlignedRead> frontier_read_reqs;
+    frontier_read_reqs.reserve(2 * beam_width);
+    std::vector<std::pair<unsigned, std::pair<unsigned, unsigned *>>>
+        cached_nhoods;
+    cached_nhoods.reserve(2 * beam_width);
+
+    std::vector<unsigned> last_io_ids;
+    last_io_ids.reserve(2 * beam_width);
+    std::vector<char> last_pages(SECTOR_LEN * beam_width * 2);
+    int n_ops = 0;
+
+    while (k < cur_list_size && num_ios < io_limit) {
+      unsigned nk = cur_list_size;
+      // clear iteration state
+      frontier.clear();
+      frontier_nhoods.clear();
+      frontier_read_reqs.clear();
+      cached_nhoods.clear();
+      sector_scratch_idx = 0;
+      // find new beam
+      _u32 marker = k;
+      _u32 num_seen = 0;
+
+      // distribute cache and disk-read nodes
+      while (marker < cur_list_size && frontier.size() < beam_width &&
+             num_seen < beam_width) {
+        const unsigned pid = id2page_[retset[marker].id];
+        if (page_visited.find(pid) == page_visited.end() && retset[marker].flag) {
+          num_seen++;
+          auto iter = nhood_cache.find(retset[marker].id);
+          if (iter != nhood_cache.end()) {
+            cached_nhoods.push_back(
+                std::make_pair(retset[marker].id, iter->second));
+            if (stats != nullptr) {
+              stats->n_cache_hits++;
+            }
+          } else {
+            frontier.push_back(retset[marker].id);
+            page_visited.insert(pid);
+          }
+          retset[marker].flag = false;
+        }
+        marker++;
+      }
+
+      // read nhoods of frontier ids
+      if (!frontier.empty()) {
+        if (stats != nullptr)
+          stats->n_hops++;
+        for (_u64 i = 0; i < frontier.size(); i++) {
+          auto                    id = frontier[i];
+          std::pair<_u32, char *> fnhood;
+          fnhood.first = id;
+          fnhood.second = sector_scratch + sector_scratch_idx * SECTOR_LEN;
+          sector_scratch_idx++;
+          frontier_nhoods.push_back(fnhood);
+          frontier_read_reqs.emplace_back(
+              (static_cast<_u64>(id2page_[id]+1)) * SECTOR_LEN, SECTOR_LEN,
+              fnhood.second);
+          if (stats != nullptr) {
+            stats->n_4k++;
+            stats->n_ios++;
+          }
+          num_ios++;
+        }
+        n_ops = reader->submit_reqs(frontier_read_reqs, ctx);
+        if (this->count_visited_nodes) {
+#pragma omp critical
+          {
+            auto &cnt = this->node_visit_counter[retset[marker].id].second;
+            ++cnt;
+          }
+        }
+      }
+
+      // compute remaining nodes in the pages that are fetched in the previous round
+      for (size_t i = 0; i < last_io_ids.size(); ++i) {
+        const unsigned last_io_id = last_io_ids[i];
+        char    *sector_buf = last_pages.data() + i * SECTOR_LEN;
+        const unsigned pid = id2page_[last_io_id];
+        const unsigned p_size = gp_layout_[pid].size();
+        // minus one for the vector that is computed previously
+        unsigned vis_size = use_ratio * (p_size - 1);
+        std::vector<std::pair<float, const char*>> vis_cand;
+        vis_cand.reserve(p_size);
+
+        // compute exact distances of the vectors within the page
+        for (unsigned j = 0; j < p_size; ++j) {
+          const unsigned id = gp_layout_[pid][j];
+          if (id == last_io_id) continue;
+          const char* node_buf = sector_buf + j * max_node_len;
+          float dist = compute_extact_dists_and_push(node_buf, id);
+          vis_cand.emplace_back(dist, node_buf);
+        }
+        if (vis_size && vis_size != p_size) {
+          std::sort(vis_cand.begin(), vis_cand.end());
+        }
+
+        // compute PQ distances for neighbours of the vectors in the page
+        for (unsigned j = 0; j < vis_size; ++j) {
+          compute_and_push_nbrs(vis_cand[j].second, nk);
+        }
+      }
+      last_io_ids.clear();
+
+      // process cached nhoods
+      for (auto &cached_nhood : cached_nhoods) {
+        auto id = cached_nhood.first;
+        auto  global_cache_iter = coord_cache.find(cached_nhood.first);
+        T *   node_fp_coords_copy = global_cache_iter->second;
+        unsigned nnr = cached_nhood.second.first;
+        unsigned* cnhood = cached_nhood.second.second;
+        char* node_buf = new char[max_node_len];
+        memcpy(node_buf, node_fp_coords_copy, disk_bytes_per_point);
+        memcpy((node_buf + disk_bytes_per_point), &nnr, sizeof(unsigned));
+        memcpy((node_buf + disk_bytes_per_point + sizeof(unsigned)), cnhood, sizeof(unsigned)*nnr);
+        compute_extact_dists_and_push(node_buf, id);
+        compute_and_push_nbrs(node_buf, nk);
+      }
+
+      // get last submitted io results, blocking
+      if (!frontier.empty()) {
+        reader->get_events(ctx, n_ops);
+      }
+
+      // compute only the desired vectors in the pages - one for each page
+      // postpone remaining vectors to the next round
+      for (auto &frontier_nhood : frontier_nhoods) {
+        char *sector_buf = frontier_nhood.second;
+        unsigned pid = id2page_[frontier_nhood.first];
+        memcpy(last_pages.data() + last_io_ids.size() * SECTOR_LEN, sector_buf, SECTOR_LEN);
+        last_io_ids.emplace_back(frontier_nhood.first);
+
+        for (unsigned j = 0; j < gp_layout_[pid].size(); ++j) {
+          unsigned id = gp_layout_[pid][j];
+          if (id == frontier_nhood.first) {
+            char *node_buf = sector_buf + j * max_node_len;
+            compute_extact_dists_and_push(node_buf, id);
+            compute_and_push_nbrs(node_buf, nk);
+          }
+        }
+      }
+
+      // update best inserted position
+      if (nk <= k)
+        k = nk;  // k is the best position in retset updated in this round.
+      else
+        ++k;
+    }
+
+    // re-sort by distance
+    std::sort(full_retset.begin(), full_retset.end(),
+              [](const Neighbor &left, const Neighbor &right) {
+                return left.distance < right.distance;
+              });
+
+    // copy k_search values
+    _u64 t = 0;
+    for (_u64 i = 0; i < full_retset.size() && t < k_search; i++) {
+      if(i > 0 && full_retset[i].id == full_retset[i-1].id){
+        std::cout << "has replica" << std::endl;
+        continue;
+      }
+      indices[t] = full_retset[i].id;
+      if (distances != nullptr) {
+        distances[t] = full_retset[i].distance;
+        if (metric == diskann::Metric::INNER_PRODUCT) {
+          // flip the sign to convert min to max
+          distances[t] = (-distances[t]);
+          // rescale to revert back to original norms (cancelling the effect of
+          // base and query pre-processing)
+          if (max_base_norm != 0)
+            distances[t] *= (max_base_norm * persist_data->query_norm);
+        }
+      }
+      t++;
+    }
+
+    if (t < k_search) {
+      diskann::cerr << "The number of unique ids is less than topk" << std::endl;
+      exit(1);
+    }
+
+    persist_data->cur_list_size = cur_list_size;
   }
   template class PQFlashIndex<_u8>;
   template class PQFlashIndex<_s8>;

--- a/src/range_search.cpp
+++ b/src/range_search.cpp
@@ -1,0 +1,518 @@
+#include "pq_flash_index.h"
+#include "timer.h"
+
+namespace diskann {
+  /*
+  typedef struct {
+    unsigned pid_;
+    bool calc_all_ = true;
+    float score_ = 0;
+    std::vector<Neighbor*> nodes_to_vis;
+  } Page;
+
+  class CandV {
+  public:
+    CandV(const _u64 L, const _u32 beam_width, 
+      tsl::robin_set<_u64>& nv, tsl::robin_set<unsigned>& pv, std::unordered_map<unsigned, unsigned>& id2pid)
+       : L_(L), bw_(beam_width), node_visited_(nv), page_visited_(pv), id2pid_(id2pid) {};
+
+    size_t size() {
+      return cands_.size();
+    }
+
+    void insert(Neighbor&& nn) {
+      // TODO: change to binary search and insert for min_cands_ to optimize large L
+      unsigned pid = id2pid_[nn.id];
+      if (page_visited_.find(pid) == page_visited_.end()) {
+        cands_.push_back(nn);
+        if (stats_.find(pid) == stats_.end()) {
+          stats_[pid].pid_ = pid;
+          stats_[pid].calc_all_ = true;
+          stats_[pid].score_ = nn.distance;
+        } else {
+          stats_[pid].score_ = std::min(stats_[pid].score_, nn.distance);
+        }
+
+        stats_[pid].nodes_to_vis.push_back(&(cands_.back()));
+      }
+    }
+
+    std::vector<Page> get_best_bw_pids() {
+      std::vector<std::pair<float, unsigned>> p_cands;
+      for (const auto& [pid, p] : stats_) {
+        p_cands.emplace_back(p.score_, p.pid_);
+      }
+      std::sort(p_cands.begin(), p_cands.end()); // TODO: bm-select
+
+      std::vector<Page> res;
+      for (_u32 i = 0; i < bw_; ++i) {
+        unsigned pid = p_cands[i].second;
+        res.push_back(std::move(stats_[pid]));
+        stats_.erase(pid);
+      }
+      return res;
+    }
+    
+    inline bool isDone(size_t res_cnt) {
+      return vis_size_ >= L_ && (res_cnt == 0 || vis_size_ >= cands_.size());
+    }
+  private:
+    _u64 L_;
+    _u32 bw_;
+    tsl::robin_set<_u64> &node_visited_;
+    tsl::robin_set<unsigned> &page_visited_;
+    std::unordered_map<unsigned, unsigned> &id2pid_;
+
+    size_t vis_size_ = 0;
+    // size_t back_marker = 0;
+    std::vector<Neighbor> cands_;
+    std::unordered_map<unsigned, Page> stats_;
+  };
+  */
+
+  template<typename T>
+  _u32 PQFlashIndex<T>::custom_range_search(const T *query1,
+                        const double range,
+                        const _u32          mem_L,
+                        const _u64          knn_min_l_search,
+                        const _u64          max_l_search,
+                        std::vector<_u64>  &indices,
+                        std::vector<float> &distances,
+                        const _u32          beam_width,
+                        const float         page_search_use_ratio,
+                        const _u32          kicked_size,
+                        const _u32          custom_round_num,
+                        QueryStats *        stats) {
+
+    Timer query_timer, cpu_timer, io_timer;
+
+    _u32 res_count = 0;
+    std::vector<MemNavNeighbor> mem_cands;
+
+    std::vector<unsigned> mem_tags(mem_L);
+    std::vector<float> mem_dis(mem_L);
+    std::vector<_u32> mem_internal_indices(mem_L);
+    std::vector<T*> mem_res = std::vector<T*>();
+    mem_index_->search_with_tags(query1, mem_L, mem_L, mem_tags.data(), mem_dis.data(), mem_internal_indices.data(), mem_res);
+
+    for (_u32 i = 0; i < mem_L; ++i) {
+      // initialization set all distance to float::max()
+      if (mem_dis[i] <= range) {
+        mem_cands.emplace_back(mem_internal_indices[i], mem_dis[i], mem_tags[i]);
+      }
+    }
+
+    // bfs to get all results in memory
+    // TODO: the internal states of `search_with_tags` might be reused during bfs
+    if (mem_cands.size() == mem_L) {
+      mem_index_->bfs_with_tags(query1, range, mem_cands);
+    }
+
+    if (mem_cands.size() == 0) {
+        return this->custom_range_search_iter_page_search(query1, range, 
+            mem_L, mem_tags, mem_dis, knn_min_l_search, max_l_search,
+            indices, distances, beam_width,
+            page_search_use_ratio, kicked_size, stats);
+    }
+
+    ThreadData<T> data = this->thread_data.pop();
+    while (data.scratch.sector_scratch == nullptr) {
+      this->thread_data.wait_for_push_notify();
+      data = this->thread_data.pop();
+    }
+
+    if (beam_width > MAX_N_SECTOR_READS)
+      throw ANNException("Beamwidth can not be higher than MAX_N_SECTOR_READS",
+                         -1, __FUNCSIG__, __FILE__, __LINE__);
+
+    // copy query to thread specific aligned and allocated memory (for distance
+    // calculations we need aligned data)
+    float        query_norm = 0;
+    const T *    query = data.scratch.aligned_query_T;
+    const float *query_float = data.scratch.aligned_query_float;
+
+    for (uint32_t i = 0; i < this->data_dim; i++) {
+      data.scratch.aligned_query_float[i] = query1[i];
+      data.scratch.aligned_query_T[i] = query1[i];
+      query_norm += query1[i] * query1[i];
+    }
+
+    // if inner product, we also normalize the query and set the last coordinate
+    // to 0 (this is the extra coordindate used to convert MIPS to L2 search)
+    if (metric == diskann::Metric::INNER_PRODUCT) {
+      query_norm = std::sqrt(query_norm);
+      data.scratch.aligned_query_T[this->data_dim - 1] = 0;
+      data.scratch.aligned_query_float[this->data_dim - 1] = 0;
+      for (uint32_t i = 0; i < this->data_dim - 1; i++) {
+        data.scratch.aligned_query_T[i] /= query_norm;
+        data.scratch.aligned_query_float[i] /= query_norm;
+      }
+    }
+
+    IOContext &ctx = data.ctx;
+    auto       query_scratch = &(data.scratch);
+
+    // reset query
+    query_scratch->reset();
+
+    // pointers to buffers for data
+    T *   data_buf = query_scratch->coord_scratch;
+    _mm_prefetch((char *) data_buf, _MM_HINT_T1);
+
+    // sector scratch
+    char *sector_scratch = query_scratch->sector_scratch;
+    _u64 &sector_scratch_idx = query_scratch->sector_idx;
+
+    // query <-> PQ chunk centers distances
+    float *pq_dists = query_scratch->aligned_pqtable_dist_scratch;
+    pq_table.populate_chunk_distances(query_float, pq_dists);
+
+    // query <-> neighbor list
+    float *dist_scratch = query_scratch->aligned_dist_scratch;
+    _u8 *  pq_coord_scratch = query_scratch->aligned_pq_coord_scratch;
+
+    tsl::robin_set<_u64> &visited = *(query_scratch->visited);
+    tsl::robin_set<unsigned> &page_visited = *(query_scratch->page_visited);
+
+    // lambda to batch compute query<-> node distances in PQ space
+    auto compute_pq_dists = [this, pq_coord_scratch, pq_dists](const unsigned *ids,
+                                                            const _u64 n_ids,
+                                                            float *dists_out) {
+      pq_flash_index_utils::aggregate_coords(ids, n_ids, this->data, this->n_chunks,
+                         pq_coord_scratch);
+      pq_flash_index_utils::pq_dist_lookup(pq_coord_scratch, n_ids, this->n_chunks, pq_dists,
+                       dists_out);
+    };
+
+    // no vector is within the radius
+    /*
+    if (mem_cands.empty()) {
+      for (_u32 i = 0; i < std::min(mem_L, mem_cand_size_when_empty); ++i) {
+      // for (_u32 i = 0; i < mem_L; ++i) {
+        if (mem_dis[i] >= std::numeric_limits<float>::max()) break;
+        mem_cands.emplace_back(mem_internal_indices[i], mem_dis[i], mem_tags[i]);
+      }
+
+      // failed to search knn results, fallback to medoid
+      if (mem_cands.empty()) {
+        _u32                        best_medoid = 0;
+        float                       best_dist = (std::numeric_limits<float>::max)();
+        for (_u64 cur_m = 0; cur_m < num_medoids; cur_m++) {
+          float cur_expanded_dist = dist_cmp_float->compare(
+              query_float, centroid_data + aligned_dim * cur_m,
+              (unsigned) aligned_dim);
+        }
+        diskann::cout << "Warning: fallback to medoid" << std::endl;
+        mem_cands.emplace_back(0, best_dist, best_medoid);
+      }
+    }
+    */
+
+    std::vector<unsigned> pages_to_vis;
+    std::vector<std::pair<unsigned, char*>> pages_to_io;
+    std::vector<AlignedRead> page_read_reqs;
+    page_read_reqs.reserve(2 * beam_width);
+
+    for (const auto& cand : mem_cands) {
+      auto pid = id2page_[cand.tag];
+      visited.insert(cand.tag);
+      if (page_visited.find(pid) == page_visited.end()) {
+        pages_to_vis.push_back(pid);
+        page_visited.insert(pid);
+      }
+    }
+
+    if (stats != nullptr) {
+      stats->cpu_us += cpu_timer.elapsed();
+    }
+
+    for (_u32 round = 0; ; ++round) {
+      if (pages_to_vis.empty() || (custom_round_num && (round >= custom_round_num))) break;
+
+      std::vector<unsigned> next_round_pages;
+      for (size_t i = 0; i < pages_to_vis.size(); i += beam_width) {
+        cpu_timer.reset();
+        pages_to_io.clear();
+        page_read_reqs.clear();
+        for (size_t j = 0; j < beam_width && (i+j < pages_to_vis.size()); ++j) {
+          std::pair<unsigned, char*> fnhood;
+          fnhood.first = pages_to_vis[i+j];
+          fnhood.second = sector_scratch + pages_to_io.size() * SECTOR_LEN;
+          pages_to_io.push_back(fnhood);
+          page_read_reqs.emplace_back(
+              static_cast<_u64>((pages_to_vis[i+j]+1)) * SECTOR_LEN, SECTOR_LEN,
+              fnhood.second);
+          if (stats != nullptr) {
+            stats->n_ios++;
+          }
+        }
+        if (stats != nullptr) {
+          stats->cpu_us += cpu_timer.elapsed();
+        }
+        io_timer.reset();
+        int n_ops = reader->submit_reqs(page_read_reqs, ctx);
+        reader->get_events(ctx, n_ops);
+        if (stats != nullptr) {
+          stats->io_us += io_timer.elapsed();
+        }
+
+        cpu_timer.reset();
+        for (const auto& fnhood : pages_to_io) {
+          auto pid = fnhood.first;
+          char *sector_buf = fnhood.second;
+          for (unsigned j = 0; j < gp_layout_[pid].size(); ++j) {
+            unsigned id = gp_layout_[pid][j];
+            char *node_buf = sector_buf + j * max_node_len;
+            memcpy(data_buf, node_buf, disk_bytes_per_point);
+            float cur_expanded_dist = dist_cmp->compare(query, data_buf,
+                                                  (unsigned) aligned_dim);
+            if (cur_expanded_dist <= range) {
+              indices.push_back(id);
+              distances.push_back(cur_expanded_dist);
+            }
+
+            unsigned *node_nbrs = OFFSET_TO_NODE_NHOOD(node_buf);
+            unsigned nnbrs = *(node_nbrs++);
+            unsigned nbors_cand_size = 0;
+            for (unsigned m = 0; m < nnbrs; ++m) {
+              if (visited.find(node_nbrs[m]) == visited.end()) {
+                node_nbrs[nbors_cand_size++] = node_nbrs[m];
+                visited.insert(node_nbrs[m]);
+              }
+            }
+            if (nbors_cand_size) {
+              compute_pq_dists(node_nbrs, nbors_cand_size, dist_scratch);
+              for (unsigned m = 0; m < nbors_cand_size; ++m) {
+                const int nbor_id = node_nbrs[m];
+                const unsigned nnbr_pid = id2page_[nbor_id];
+                const float nbor_dist = dist_scratch[m];
+                if (nbor_dist <= range && page_visited.find(nnbr_pid) == page_visited.end()) {
+                  next_round_pages.push_back(nnbr_pid);
+                  page_visited.insert(nnbr_pid);
+                }
+              }
+            }
+          }
+        }
+        if (stats != nullptr) {
+          stats->cpu_us += cpu_timer.elapsed();
+        }
+      }
+      pages_to_vis.swap(next_round_pages);
+    }
+
+    if (stats != nullptr) {
+      stats->total_us = (double) query_timer.elapsed();
+    }
+
+    this->thread_data.push(data);
+    this->thread_data.push_notify_all();
+
+    return indices.size();
+  }
+
+  // range search returns results of all neighbors within distance of range.
+  // indices and distances need to be pre-allocated of size l_search and the
+  // return value is the number of matching hits.
+  template<typename T>
+  _u32 PQFlashIndex<T>::range_search_iter_knn(const T *query1, const double range,
+                                     const _u32          mem_L,
+                                     const _u64          min_l_search,
+                                     const _u64          max_l_search,
+                                     std::vector<_u64> & indices,
+                                     std::vector<float> &distances,
+                                     const _u64          min_beam_width,
+                                     const float         page_search_use_ratio,
+                                     QueryStats *        stats) {
+    Timer query_timer;
+    _u32 res_count = 0;
+
+    bool stop_flag = false;
+
+    _u32 l_search = min_l_search;  // starting size of the candidate list
+    while (!stop_flag) {
+      indices.resize(l_search);
+      distances.resize(l_search);
+      _u64 cur_bw =
+          min_beam_width > (l_search / 5) ? min_beam_width : l_search / 5;
+      cur_bw = (cur_bw > 100) ? 100 : cur_bw;
+      for (auto &x : distances)
+        x = std::numeric_limits<float>::max();
+      
+      if (use_page_search_) {
+        this->page_search(query1, l_search, mem_L, l_search, indices.data(),
+                               distances.data(), cur_bw,
+                               std::numeric_limits<_u32>::max(),
+                               false, page_search_use_ratio, stats);
+      } else {
+        this->cached_beam_search(query1, l_search, l_search, indices.data(),
+                               distances.data(), cur_bw, false, stats, mem_L);
+      }
+      for (_u32 i = 0; i < l_search; i++) {
+        if (distances[i] > (float) range) {
+          res_count = i;
+          break;
+        } else if (i == l_search - 1)
+          res_count = l_search;
+      }
+      if (res_count < (_u32)(l_search / 2.0))
+        stop_flag = true;
+      l_search = l_search * 2;
+      if (l_search > max_l_search)
+        stop_flag = true;
+    }
+    if (stats != nullptr) {
+      stats->total_us = (double) query_timer.elapsed();
+    }
+    indices.resize(res_count);
+    distances.resize(res_count);
+    return res_count;
+  }
+
+  template<typename T>
+  _u32 PQFlashIndex<T>::custom_range_search_iter_page_search(
+                                     const T *query1, const double range,
+                                     const _u32          mem_L,
+                                     std::vector<unsigned> &upper_mem_tags,
+                                     std::vector<float> &upper_mem_dis,
+                                     const _u64          min_l_search,
+                                     const _u64          max_l_search,
+                                     std::vector<_u64> & indices,
+                                     std::vector<float> &distances,
+                                     const _u64          min_beam_width,
+                                     const float         page_search_use_ratio,
+                                     const _u32          kicked_size,
+                                     QueryStats *        stats) {
+    _u32 res_count = 0;
+
+    bool stop_flag = false;
+
+    _u32 l_search = min_l_search;  // starting size of the candidate list
+    PageSearchPersistData<T> persist_data;
+    ThreadData<T>& data = persist_data.thread_data;
+    data = this->thread_data.pop();
+    while (data.scratch.sector_scratch == nullptr) {
+      this->thread_data.wait_for_push_notify();
+      persist_data.thread_data = this->thread_data.pop();
+    }
+    persist_data.full_ret_set.reserve(4096);
+    std::vector<Neighbor> &retset = persist_data.ret_set;
+    NeighborVec &kicked = persist_data.kicked;
+    kicked.set_cap(kicked_size);
+    unsigned &cur_list_size = persist_data.cur_list_size;
+    cur_list_size = 0;
+
+    float        query_norm = 0;
+    const T *    query = data.scratch.aligned_query_T;
+    const float *query_float = data.scratch.aligned_query_float;
+
+    for (uint32_t i = 0; i < this->data_dim; i++) {
+      data.scratch.aligned_query_float[i] = query1[i];
+      data.scratch.aligned_query_T[i] = query1[i];
+      query_norm += query1[i] * query1[i];
+    }
+
+    if (metric == diskann::Metric::INNER_PRODUCT) {
+      query_norm = std::sqrt(query_norm);
+      data.scratch.aligned_query_T[this->data_dim - 1] = 0;
+      data.scratch.aligned_query_float[this->data_dim - 1] = 0;
+      for (uint32_t i = 0; i < this->data_dim - 1; i++) {
+        data.scratch.aligned_query_T[i] /= query_norm;
+        data.scratch.aligned_query_float[i] /= query_norm;
+      }
+    }
+    persist_data.query_norm = query_norm;
+
+    IOContext &ctx = data.ctx;
+    auto       query_scratch = &(data.scratch);
+    query_scratch->reset();
+    T *   data_buf = query_scratch->coord_scratch;
+    float *pq_dists = query_scratch->aligned_pqtable_dist_scratch;
+    pq_table.populate_chunk_distances(query_float, pq_dists);
+    tsl::robin_set<_u64> &visited = *(query_scratch->visited);
+
+    Timer query_timer;
+
+    retset.resize(l_search+1);
+    std::vector<T*> mem_res = std::vector<T*>();
+    if (upper_mem_tags.size() < mem_L) {
+      upper_mem_tags.resize(mem_L);
+      upper_mem_dis.resize(mem_L);
+      mem_index_->search_with_tags(query1, mem_L, mem_L, upper_mem_tags.data(), upper_mem_dis.data(), nullptr, mem_res);
+    }
+
+    for (size_t i = 0; i < std::min(mem_L, l_search); ++i) {
+      retset[cur_list_size].id = upper_mem_tags[i];
+      retset[cur_list_size].distance = upper_mem_dis[i];
+      retset[cur_list_size++].flag = true;
+      visited.insert(upper_mem_tags[i]);
+    }
+
+    while (!stop_flag) {
+      indices.resize(l_search);
+      distances.resize(l_search);
+
+      _u64 cur_bw = min_beam_width;
+
+      for (auto &x : distances)
+        x = std::numeric_limits<float>::max();
+      
+      this->page_search_interim(query1, l_search, mem_L, l_search, indices.data(),
+                               distances.data(), cur_bw,
+                               std::numeric_limits<_u32>::max(),
+                               false, page_search_use_ratio, stats, &persist_data);
+
+      for (_u32 i = 0; i < l_search; i++) {
+        if (distances[i] > (float) range) {
+          res_count = i;
+          break;
+        } else if (i == l_search - 1)
+          res_count = l_search;
+      }
+      if (res_count < (_u32)(l_search / 2.0))
+        stop_flag = true;
+      
+      retset.resize(2*l_search+1);
+      size_t moved_num = kicked.move_to(retset, cur_list_size, l_search);
+      cur_list_size += moved_num;
+
+      l_search = l_search * 2;
+      if (l_search > max_l_search)
+        stop_flag = true;
+    }
+
+    if (stats != nullptr) {
+      stats->total_us = (double) query_timer.elapsed();
+    }
+
+    this->thread_data.push(persist_data.thread_data);
+    this->thread_data.push_notify_all();
+
+    indices.resize(res_count);
+    distances.resize(res_count);
+    return res_count;
+  }
+
+#ifdef EXEC_ENV_OLS
+  template<typename T>
+  char *PQFlashIndex<T>::getHeaderBytes() {
+    IOContext & ctx = reader->get_ctx();
+    AlignedRead readReq;
+    readReq.buf = new char[PQFlashIndex<T>::HEADER_SIZE];
+    readReq.len = PQFlashIndex<T>::HEADER_SIZE;
+    readReq.offset = 0;
+
+    std::vector<AlignedRead> readReqs;
+    readReqs.push_back(readReq);
+
+    reader->read(readReqs, ctx, false);
+
+    return (char *) readReq.buf;
+  }
+#endif
+
+  // instantiations
+  template class PQFlashIndex<_u8>;
+  template class PQFlashIndex<_s8>;
+  template class PQFlashIndex<float>;
+} // namespace diskann

--- a/src/visit_freq.cpp
+++ b/src/visit_freq.cpp
@@ -8,7 +8,7 @@ namespace diskann {
         const T *query, const size_t query_aligned_dim, const _u64 k_search,
         const _u64 l_search, _u64 *res_ids,
         float *res_dists, const _u64 beam_width, const _u32 io_limit,
-        const bool use_reorder_data, QueryStats *stats) {
+        const bool use_reorder_data, QueryStats *stats, const _u32 mem_L) {
 
     this->count_visited_nodes = true;
     this->count_visited_nbrs = true;
@@ -24,7 +24,7 @@ namespace diskann {
           query + (i * query_aligned_dim), k_search, l_search,
           res_ids + (i * k_search),
           res_dists + (i * k_search),
-          beam_width, io_limit, use_reorder_data, stats + i);
+          beam_width, io_limit, use_reorder_data, stats + i, mem_L);
     }
     this->count_visited_nbrs = false;
     this->count_visited_nodes = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,8 +18,8 @@ target_link_libraries(search_disk_index ${PROJECT_NAME} ${DISKANN_ASYNC_LIB} ${D
 add_executable(range_search_disk_index range_search_disk_index.cpp)
 target_link_libraries(range_search_disk_index ${PROJECT_NAME} ${DISKANN_ASYNC_LIB} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
 
-add_executable(range_search_disk_different_radius range_search_disk_different_radius.cpp)
-target_link_libraries(range_search_disk_different_radius ${PROJECT_NAME} ${DISKANN_ASYNC_LIB} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
+# add_executable(range_search_disk_different_radius range_search_disk_different_radius.cpp)
+# target_link_libraries(range_search_disk_different_radius ${PROJECT_NAME} ${DISKANN_ASYNC_LIB} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
 #add_executable(test_incremental_index test_incremental_index.cpp)
 #target_link_libraries(test_incremental_index ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
 

--- a/tests/search_disk_index.cpp
+++ b/tests/search_disk_index.cpp
@@ -61,7 +61,7 @@ int search_disk_index(
     const unsigned num_threads, const unsigned recall_at,
     const unsigned beamwidth, const unsigned num_nodes_to_cache,
     const _u32 search_io_limit, const std::vector<unsigned>& Lvec,
-    const _u32 mem_topk, const _u32 mem_L,
+    const _u32 mem_L,
     const bool use_page_search=true,
     const float use_ratio=1.0,
     const bool use_reorder_data = false) {
@@ -109,7 +109,7 @@ int search_disk_index(
 #endif
 
   std::unique_ptr<diskann::PQFlashIndex<T>> _pFlashIndex(
-      new diskann::PQFlashIndex<T>(reader, metric, use_page_search));
+      new diskann::PQFlashIndex<T>(reader, use_page_search, metric));
 
   int res = _pFlashIndex->load(num_threads, index_path_prefix.c_str(), disk_file_path);
 
@@ -119,7 +119,7 @@ int search_disk_index(
 
   // load in-memory navigation graph
   if (mem_L) {
-    _pFlashIndex->load_mem_index(metric, query_dim, mem_index_path, num_threads, mem_L, mem_topk);
+    _pFlashIndex->load_mem_index(metric, query_dim, mem_index_path, num_threads, mem_L);
   }
 
   // cache bfs levels
@@ -129,7 +129,7 @@ int search_disk_index(
   //_pFlashIndex->cache_bfs_levels(num_nodes_to_cache, node_list);
   if (num_nodes_to_cache > 0)
     _pFlashIndex->generate_cache_list_from_sample_queries(
-        warmup_query_file, 15, 6, num_nodes_to_cache, num_threads, node_list, use_page_search);
+        warmup_query_file, 15, 6, num_nodes_to_cache, num_threads, node_list, use_page_search, mem_L);
   _pFlashIndex->load_cache_list(node_list);
   node_list.clear();
   node_list.shrink_to_fit();
@@ -228,7 +228,7 @@ int search_disk_index(
 #pragma omp parallel for schedule(dynamic, 1)
       for (_s64 i = 0; i < (int64_t) query_num; i++) {
         _pFlashIndex->page_search(
-            query + (i * query_aligned_dim), recall_at, L,
+            query + (i * query_aligned_dim), recall_at, mem_L, L,
             query_result_ids_64.data() + (i * recall_at),
             query_result_dists[test_id].data() + (i * recall_at),
             optimized_beamwidth, search_io_limit, use_reorder_data, use_ratio, stats + i);
@@ -240,7 +240,7 @@ int search_disk_index(
             query + (i * query_aligned_dim), recall_at, L,
             query_result_ids_64.data() + (i * recall_at),
             query_result_dists[test_id].data() + (i * recall_at),
-            optimized_beamwidth, search_io_limit, use_reorder_data, stats + i);
+            optimized_beamwidth, search_io_limit, use_reorder_data, stats + i, mem_L);
       }
     }
     auto                          e = std::chrono::high_resolution_clock::now();
@@ -313,7 +313,7 @@ int main(int argc, char** argv) {
   std::string data_type, dist_fn, index_path_prefix, result_path_prefix,
       query_file, gt_file, disk_file_path, mem_index_path;
   unsigned              num_threads, K, W, num_nodes_to_cache, search_io_limit;
-  unsigned              mem_topk, mem_L;
+  unsigned              mem_L;
   std::vector<unsigned> Lvec;
   bool                  use_reorder_data = false;
   bool                  use_page_search = true;
@@ -366,8 +366,6 @@ int main(int argc, char** argv) {
                        "conjuction with compressed data on SSD.");
     desc.add_options()("mem_L", po::value<unsigned>(&mem_L)->default_value(0),
                        "The L of the in-memory navigation graph while searching. Use 0 to disable");
-    desc.add_options()("mem_topk", po::value<unsigned>(&mem_topk)->default_value(0),
-                       "The TopK of the in-memory navigation graph.");
     desc.add_options()("use_page_search", po::value<bool>(&use_page_search)->default_value(1),
                        "Use 1 for page search (default), 0 for DiskANN beam search");
     desc.add_options()("use_ratio", po::value<float>(&use_ratio)->default_value(1.0f),
@@ -403,10 +401,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  if (!validate_mem_index_params(mem_topk, mem_L)) {
-    return -1;
-  }
-
   if (use_ratio < 0 || use_ratio > 1.0f) {
     std::cout << "use_ratio should be in the range [0, 1] (inclusive)." << std::endl;
     return -1;
@@ -433,18 +427,18 @@ int main(int argc, char** argv) {
                                       result_path_prefix, query_file, gt_file,
                                       disk_file_path,
                                       num_threads, K, W, num_nodes_to_cache,
-                                      search_io_limit, Lvec, mem_topk, mem_L, use_page_search, use_ratio, use_reorder_data);
+                                      search_io_limit, Lvec, mem_L, use_page_search, use_ratio, use_reorder_data);
     else if (data_type == std::string("int8"))
       return search_disk_index<int8_t>(metric, index_path_prefix,
                                        mem_index_path,
                                        result_path_prefix, query_file, gt_file,
                                        disk_file_path,
                                        num_threads, K, W, num_nodes_to_cache,
-                                       search_io_limit, Lvec, mem_topk, mem_L, use_page_search, use_ratio, use_reorder_data);
+                                       search_io_limit, Lvec, mem_L, use_page_search, use_ratio, use_reorder_data);
     else if (data_type == std::string("uint8"))
       return search_disk_index<uint8_t>(
           metric, index_path_prefix, mem_index_path, result_path_prefix, query_file, gt_file,
-          disk_file_path, num_threads, K, W, num_nodes_to_cache, search_io_limit, Lvec, mem_topk, mem_L,
+          disk_file_path, num_threads, K, W, num_nodes_to_cache, search_io_limit, Lvec, mem_L,
           use_page_search, use_ratio, use_reorder_data);
     else {
       std::cerr << "Unsupported data type. Use float or int8 or uint8"

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -129,7 +129,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
       } else if (tags) {
         index.search_with_tags(query + i * query_aligned_dim, recall_at, L,
                                query_result_tags.data() + i * recall_at,
-                               nullptr, res);
+                               nullptr, nullptr, res);
         for (int64_t r = 0; r < (int64_t) recall_at; r++) {
           query_result_ids[test_id][recall_at * i + r] =
               query_result_tags[recall_at * i + r];

--- a/tests/search_memory_index_dynamic.cpp
+++ b/tests/search_memory_index_dynamic.cpp
@@ -106,7 +106,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
       auto qs = std::chrono::high_resolution_clock::now();
       cmp_stats[i] = index.search_with_tags(
           query + i * query_aligned_dim, recall_at, L,
-          query_result_tags + i * recall_at, nullptr, res);
+          query_result_tags + i * recall_at, nullptr, nullptr, res);
 
       auto qe = std::chrono::high_resolution_clock::now();
       std::chrono::duration<double> diff = qe - qs;

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -72,7 +72,7 @@ add_executable(parse_freq_file parse_freq_file.cpp)
 target_link_libraries(parse_freq_file ${PROJECT_NAME})
 
 # formatter
-if (LINUX)
-	add_custom_command(TARGET gen_random_slice PRE_BUILD COMMAND clang-format -i ../../../include/*.h ../../../include/dll/*.h ../../../src/*.cpp  ../../../tests/*.cpp ../../../src/dll/*.cpp ../../../tests/utils/*.cpp)
-endif()
+# if (LINUX)
+# 	add_custom_command(TARGET gen_random_slice PRE_BUILD COMMAND clang-format -i ../../../include/*.h ../../../include/dll/*.h ../../../src/*.cpp  ../../../tests/*.cpp ../../../src/dll/*.cpp ../../../tests/utils/*.cpp)
+# endif()
 


### PR DESCRIPTION
This PR contains
1. Add custom range search
2. Add reuse intermediate results range search which iterates page search
3. Remove `mem_topk`
4. Modifies in-memory index path